### PR TITLE
Info about bot environments, added configuration parsing, tests for bot startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab91ebe16eb252986481c5b62f6098f3b698a45e34b5b98200cf20dd2484a44"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "317b9a89c1868f5ea6ff1d9539a69f45dffc21ce321ac1fd1160dfa48c8e2140"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0699d10d2f4d628a98ee7b57b289abbc98ff3bad977cb3152709d4bf2330628"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "antidote"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +172,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2275f18819641850fa26c89acc84d465c1bf91ce57bc2748b28c420473352f64"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07cdf1b148b25c1e1f7a42225e30a0d99a615cd4637eae7365548dd4529b95bc"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +263,12 @@ dependencies = [
  "sodiumoxide",
  "websocket",
 ]
+
+[[package]]
+name = "dotenv"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "ed25519"
@@ -236,6 +336,12 @@ dependencies = [
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
@@ -804,6 +910,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "2.0.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +1028,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,7 +1055,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "vertex"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "discord",
+ "dotenv",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.4.8", features = ["derive", "env"] }
 discord = { git = "https://github.com/SpaceManiac/discord-rs" }
+dotenv = "0.15.0"

--- a/README.md
+++ b/README.md
@@ -8,15 +8,12 @@ A Discord bot for the best Discord community out there, TriDev. Vertex comes jam
 2. Open an issue for @jaketothepast to add you to the Discord developer team.
 3. Compile and run the bot locally, with the correct Discord bot token.
 
-## Discord Environments
+## Running the Bot
 
-We currently have two applications
-
-1. Vertex - the production app, used to power our prod bot user.
-2. Vertex Test - our private app, used as a staging ground for new bot features.
-
-We also have the test server: Vertex-Test. This server is used as our development environment.
-
-## Production
-
-Currently running in DigitalOcean.
+1. Go to Discord developer portal
+2. Create a new application
+3. Create a new bot user
+4. Generate the invite link.
+5. Add the bot to your server with the link.
+6. Use the bot token as an environment variable `BOT_TOKEN` to start the app
+7. Start the bot, profit!

--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ We currently have two applications
 
 1. Vertex - the production app, used to power our prod bot user.
 2. Vertex Test - our private app, used as a staging ground for new bot features.
+
+We also have the test server: Vertex-Test. This server is used as our development environment.
+
+## Production
+
+Currently running in DigitalOcean.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Vertex
+
+A Discord bot for the best Discord community out there, TriDev. Vertex comes jam packed with features that make your community come alive. Curl up by a nice Flame War Friday, and enjoy the ride
+
+## Getting Started
+
+1. Install the Rust toolchain for your system: https://www.rust-lang.org/learn/get-started
+2. Open an issue for @jaketothepast to add you to the Discord developer team.
+3. Compile and run the bot locally, with the correct Discord bot token.
+
+## Discord Environments
+
+We currently have two applications
+
+1. Vertex - the production app, used to power our prod bot user.
+2. Vertex Test - our private app, used as a staging ground for new bot features.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,57 @@
 use discord::Discord;
+use clap::Parser;
+use dotenv::dotenv;
 
 extern crate discord;
 
+// TODO: Better validation of Discord token.
+const BOT_TOKEN_LENGTH: usize = 72;
+
+/// Tri-Cities Vertex Discord Bot
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+pub struct Config {
+    /// Your bot token you got from Discord Developer portal.
+    #[arg(short, long, env("BOT_TOKEN"))]
+    pub bot_token: String
+}
+
+impl Config {
+    pub fn from_env_and_args() -> Self {
+        dotenv().ok();
+        Self::parse()
+    }
+}
+
+fn get_discord(bot_token: &str) -> Discord {
+    if bot_token.len() < BOT_TOKEN_LENGTH {
+        panic!("invalid bot token");
+    }
+
+    return match Discord::from_bot_token(bot_token) {
+        Ok(discord) => discord,
+        Err(err) => panic!("error happened: {}", err)
+    }
+}
+
 fn main() {
-    println!("Hello, world!");
-    let discord = Discord::from_bot_token("my_token");
+    let cfg = Config::from_env_and_args();
+    let discord = get_discord(cfg.bot_token.as_str());
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::get_discord;
+
+    #[test]
+    #[should_panic]
+    fn invalid_bot_token_errors() {
+        get_discord("invalid");
+    }
+
+    #[test]
+    fn valid_bot_token_no_error() {
+        // Our only validation rule right now is length
+        get_discord("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    }
 }


### PR DESCRIPTION
## Additions

- Configuration parsing, right now just for bot token, that uses `.env` OR command line arguments via `dotenv` and `clap` crates.
- Wrapped Discord gateway in create function, covered in tests

Closes #4
Closes #3 